### PR TITLE
Test airport fails: Wuxi airport

### DIFF
--- a/faker_airtravel/tests/test_airports.py
+++ b/faker_airtravel/tests/test_airports.py
@@ -30,7 +30,7 @@ def test_dict_keys(airports, test_input):
 
 def test_airport_name():
     name = fake.airport_name()
-    assert len(name) > 4
+    assert len(name) >= 4
 
 
 def test_iata():


### PR DESCRIPTION
The test which check the airport name length fails if the Wuxi airport is returned.

`{
    'airport': 'Wuxi',
    'iata': 'WUX',
    'icao': '',
    'city': 'Wuxi',
    'state': 'Jiangsu',
    'country': 'China'
}`